### PR TITLE
Corrige login e barra de progresso

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,6 @@
   <header>
     <h1>Roadmap Cientista de Dados</h1>
     <p class="subtitle">Pronta para iniciar sua jornada de estudos?</p>
-    <div id="progress-container">
-      <div id="progress-bar"><span id="progress-text">0%</span></div>
-</div>
     <div id="auth">
       <p id="auth-message" class="login-info">faça login para salvar seu progresso</p>
       <p id="user-email" class="login-info" style="display:none;"></p>
@@ -25,6 +22,9 @@
 
       <button id="logout-btn" style="display:none;">Sair</button>
 
+    </div>
+    <div id="progress-container">
+      <div id="progress-bar"><span id="progress-text">0%</span></div>
     </div>
     <nav>
       <ul class="menu">
@@ -209,7 +209,6 @@
     <p>Me siga nas redes sociais <strong>@pythonicah</strong></p>
     <p>&copy; 2025</p>
   </footer>
-  <script src="supabase.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -33,11 +33,12 @@ header .subtitle {
 }
 
 #progress-container {
-  width: 100%;
+  width: 90%;
+  max-width: 960px;
   background-color: #000;
   border-radius: 8px;
   overflow: hidden;
-  margin: 1rem 0;
+  margin: 1rem auto;
 }
 
 #auth {


### PR DESCRIPTION
## Resumo
- move a barra de progresso para baixo do login
- ajusta largura máxima da barra
- remove dependência do supabase
- implementa login simples com LocalStorage
- mantém preenchimento da barra ao marcar checkboxes

## Testes
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_687275103050832d9f4c05b7f83cd572